### PR TITLE
Fix Link to NPM Package unset-value

### DIFF
--- a/src/unset-value.ts
+++ b/src/unset-value.ts
@@ -1,5 +1,5 @@
 /**
- * https://www.npmjs.com/package/unset-values
+ * https://www.npmjs.com/package/unset-value
  */
 import has from 'has-value';
 import isObject from 'isobject';


### PR DESCRIPTION
The link to the unset-value npm package was wrong, so I fixed it:

https://www.npmjs.com/package/unset-values --> https://www.npmjs.com/package/unset-value

This link was found with [link-inspector](https://github.com/justindhillon/link-inspector), if you find this pr useful, give the repo a :star: 